### PR TITLE
Fixed paired end mapq calc

### DIFF
--- a/pairedCapper.py
+++ b/pairedCapper.py
@@ -75,7 +75,7 @@ class PairedRead(Read):
                                                        equivalent_or_better_clusters, equivalent_clusters,
                                                        equivalent_clusters_kept, cluster_score, alignment_score))
 
-            self.alignment_scores = sorted(alignment_scores)
+            self.alignment_scores = sorted(alignment_scores, key=lambda x : x.alignment_score)
 
 
         #print("Alignment scores", self.alignment_scores)


### PR DESCRIPTION
This fixes the mapq calculation to match vg's. The notebook assumed that alignment_scores was sorted by the score of the pairs, this makes that true